### PR TITLE
Added parentStyle property to all widgets

### DIFF
--- a/react-tradingview-embed/src/components/AdvancedChart.tsx
+++ b/react-tradingview-embed/src/components/AdvancedChart.tsx
@@ -26,6 +26,7 @@ export type AdvancedChartWidgetProps = {
 }
 
 type AdvancedChartProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: AdvancedChartWidgetProps;
   widgetPropsAny?: any;
   children?: never;

--- a/react-tradingview-embed/src/components/CompanyProfile.tsx
+++ b/react-tradingview-embed/src/components/CompanyProfile.tsx
@@ -11,6 +11,7 @@ export type CompanyProfileWidgetProps = {
 }
 
 type CompanyProfileProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: CompanyProfileWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -55,7 +56,7 @@ const CompanyProfile = (props: CompanyProfileProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default CompanyProfile;

--- a/react-tradingview-embed/src/components/CryptocurrencyMarket.tsx
+++ b/react-tradingview-embed/src/components/CryptocurrencyMarket.tsx
@@ -12,6 +12,7 @@ export type CryptocurrencyMarketWidgetProps = {
 }
 
 type CryptocurrencyMarketProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: CryptocurrencyMarketWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -57,7 +58,7 @@ const CryptocurrencyMarket = (props: CryptocurrencyMarketProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default CryptocurrencyMarket;

--- a/react-tradingview-embed/src/components/EconomicCalendar.tsx
+++ b/react-tradingview-embed/src/components/EconomicCalendar.tsx
@@ -11,6 +11,7 @@ export type EconomicCalendarWidgetProps = {
 }
 
 type EconomicCalendarProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: EconomicCalendarWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -55,7 +56,7 @@ const EconomicCalendar = (props: EconomicCalendarProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default EconomicCalendar;

--- a/react-tradingview-embed/src/components/ForexCrossRates.tsx
+++ b/react-tradingview-embed/src/components/ForexCrossRates.tsx
@@ -11,6 +11,7 @@ export type ForexCrossRatesWidgetProps = {
 }
 
 type ForexCrossRatesProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: ForexCrossRatesWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -65,7 +66,7 @@ const ForexCrossRates = (props: ForexCrossRatesProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default ForexCrossRates;

--- a/react-tradingview-embed/src/components/ForexHeatMap.tsx
+++ b/react-tradingview-embed/src/components/ForexHeatMap.tsx
@@ -11,6 +11,7 @@ export type ForexHeatMapWidgetProps = {
 }
 
 type ForexHeatMapProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: ForexHeatMapWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -65,7 +66,7 @@ const ForexHeatMap = (props: ForexHeatMapProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default ForexHeatMap;

--- a/react-tradingview-embed/src/components/FundamentalData.tsx
+++ b/react-tradingview-embed/src/components/FundamentalData.tsx
@@ -13,6 +13,7 @@ export type FundamentalDataWidgetProps = {
 }
 
 type FundamentalDataProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: FundamentalDataWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -59,7 +60,7 @@ const FundamentalData = (props: FundamentalDataProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default FundamentalData;

--- a/react-tradingview-embed/src/components/MarketData.tsx
+++ b/react-tradingview-embed/src/components/MarketData.tsx
@@ -12,6 +12,7 @@ export type MarketDataWidgetProps = {
 }
 
 type MarketDataProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: MarketDataWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -172,7 +173,7 @@ const MarketData = (props: MarketDataProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default MarketData;

--- a/react-tradingview-embed/src/components/MarketOverview.tsx
+++ b/react-tradingview-embed/src/components/MarketOverview.tsx
@@ -22,6 +22,7 @@ export type MarketOverviewWidgetProps = {
 }
 
 type MarketOverviewProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: MarketOverviewWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -76,7 +77,7 @@ const MarketOverview = (props: MarketOverviewProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default MarketOverview;

--- a/react-tradingview-embed/src/components/MiniChart.tsx
+++ b/react-tradingview-embed/src/components/MiniChart.tsx
@@ -16,6 +16,7 @@ export type MiniChartWidgetProps = {
 }
 
 type MiniChartProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: MiniChartWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -65,7 +66,7 @@ const MiniChart = (props: MiniChartProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default MiniChart;

--- a/react-tradingview-embed/src/components/Screener.tsx
+++ b/react-tradingview-embed/src/components/Screener.tsx
@@ -13,6 +13,7 @@ export type ScreenerWidgetProps = {
 }
 
 type ScreenerProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: ScreenerWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -59,7 +60,7 @@ const Screener = (props: ScreenerProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default Screener;

--- a/react-tradingview-embed/src/components/SingleTicker.tsx
+++ b/react-tradingview-embed/src/components/SingleTicker.tsx
@@ -10,6 +10,7 @@ export type SingleTickerWidgetProps = {
 }
 
 type SingleTickerProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: SingleTickerWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -53,7 +54,7 @@ const SingleTicker = (props: SingleTickerProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default SingleTicker;

--- a/react-tradingview-embed/src/components/StockMarket.tsx
+++ b/react-tradingview-embed/src/components/StockMarket.tsx
@@ -22,6 +22,7 @@ export type StockMarketWidgetProps = {
 }
 
 type StockMarketProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: StockMarketWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -77,7 +78,7 @@ const StockMarket = (props: StockMarketProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default StockMarket;

--- a/react-tradingview-embed/src/components/SymbolInfo.tsx
+++ b/react-tradingview-embed/src/components/SymbolInfo.tsx
@@ -10,6 +10,7 @@ export type SymbolInfoWidgetProps = {
 }
 
 type SymbolInfoProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: SymbolInfoWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -53,7 +54,7 @@ const SymbolInfo = (props: SymbolInfoProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default SymbolInfo;

--- a/react-tradingview-embed/src/components/SymbolOverview.tsx
+++ b/react-tradingview-embed/src/components/SymbolOverview.tsx
@@ -21,6 +21,7 @@ export type SymbolOverviewWidgetProps = {
 }
 
 type SymbolOverviewProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: SymbolOverviewWidgetProps;
   widgetPropsAny?: any;
   children?: never;

--- a/react-tradingview-embed/src/components/TechnicalAnalysis.tsx
+++ b/react-tradingview-embed/src/components/TechnicalAnalysis.tsx
@@ -13,6 +13,7 @@ export type TechnicalAnalysisWidgetProps = {
 }
 
 type TechnicalAnalysisProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: TechnicalAnalysisWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -59,7 +60,7 @@ const TechnicalAnalysis = (props: TechnicalAnalysisProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default TechnicalAnalysis;

--- a/react-tradingview-embed/src/components/Ticker.tsx
+++ b/react-tradingview-embed/src/components/Ticker.tsx
@@ -10,6 +10,7 @@ export type TickerWidgetProps = {
 }
 
 type TickerProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: TickerWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -74,7 +75,7 @@ const Ticker = (props: TickerProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default Ticker;

--- a/react-tradingview-embed/src/components/TickerTape.tsx
+++ b/react-tradingview-embed/src/components/TickerTape.tsx
@@ -11,6 +11,7 @@ export type TickerTapeWidgetProps = {
 }
 
 type TickerTapeProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: TickerTapeWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -76,7 +77,7 @@ const TickerTape = (props: TickerTapeProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default TickerTape;

--- a/react-tradingview-embed/src/components/Timeline.tsx
+++ b/react-tradingview-embed/src/components/Timeline.tsx
@@ -11,6 +11,7 @@ export type TimelineWidgetProps = {
 }
 
 type TimelineProps = {
+  parentStyle?: React.CSSProperties;
   widgetProps?: TimelineWidgetProps;
   widgetPropsAny?: any;
   children?: never;
@@ -55,7 +56,7 @@ const Timeline = (props: TimelineProps) => {
     }
   }, [ref, widgetProps, widgetPropsAny]);
 
-  return <div ref={ref} />;
+  return <div style={props.parentStyle} ref={ref} />;
 }
 
 export default Timeline;


### PR DESCRIPTION
This allows the user to optionally set style on the parent `div` of each widget.

Named the property `parentStyle` rather than `style` due to a potential confusion in `AdvancedChart.tsx`'s `widgetProps`. If no problem seen here, happy to change the property name to just `style`.